### PR TITLE
generate geonames IRIs for vocab.sentier

### DIFF
--- a/sentier_vocab/geonames_iri_terms.py
+++ b/sentier_vocab/geonames_iri_terms.py
@@ -124,7 +124,7 @@ def generateGeonameVocabulary(world_path: str, hierarchy_path: str, altnames_pat
     alternate_names = pl.scan_csv(altnames_path, schema=alt_schema, separator="\t")
 
     filtered_world = world_frame.sql(
-        "select * from self where feature_code in ('PCLI', 'RGN', 'ADM1')"
+        "select * from self where feature_code in ('PCLI', 'PCLD', 'RGN', 'ADM1')"
     )
     filtered_alt_names = alternate_names.join(
         filtered_world, on="geonameid",how="full"

--- a/sentier_vocab/geonames_iri_terms.py
+++ b/sentier_vocab/geonames_iri_terms.py
@@ -134,7 +134,7 @@ def generateGeonameVocabulary(world_path: str, hierarchy_path: str, altnames_pat
 
     world = Graph()
 
-    for item in tqdm(filtered_world.iter_rows(),total=filtered_world.height):
+    for item in filtered_world.iter_rows():
         uri = URIRef(GEOSPACES + str(item[0]))
         world.add((
             uri,


### PR DESCRIPTION
Updated version, now contains all altnames and prefnames with langauge code included (when provided).
Links to the source of the alternateNamesV2.zip.

geonames-iri.ttl is now ~8.6MB. Size can be further reduced by removing 'ADM1' from the filtered_world frame.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [X] I'm aware of the [code of conduct](https://github.com/sentier-dev.github/blob/main/CODE_OF_CONDUCT.md).
- [X] I'm aware of the [contributing guidelines](https://github.com/sentier-dev/sentier.dev/blob/main/Engineering/CONTRIBUTING.md).
- [X] I've created [logical separate commits](https://github.com/sentier-dev/sentier.dev/blob/main/Engineering/CONTRIBUTING.md#git-commits) and followed the [commit message format](https://github.com/sentier-dev/sentier.dev/blob/main/Engineering/CONTRIBUTING.md#git-commits).
- [X] If this PR resolves or addresses an issue, I've linked it in the [commit message](https://github.com/sentier-dev/sentier.dev/blob/main/Engineering/CONTRIBUTING.md#git-commits).
- [X] I've added relevant test cases.
- [X] I've added relevant documentation.
- [X] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added third-party code (copy/pasted or new dependencies), please make sure this has been discussed in a github issue.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
